### PR TITLE
initial revision of schedule.json export

### DIFF
--- a/_pages/schedule.json.liquid
+++ b/_pages/schedule.json.liquid
@@ -1,0 +1,88 @@
+---
+permalink: /schedule.json
+layout: null
+---
+{
+  "schedule": {
+    "version": "0.1",
+    "base_url": "https://laborluxeria.github.io/winterchaos2022/schedule/",
+    "conference": {
+      "acronym": "winterchaos-2022",
+      "title": "Winterchaos",
+      "start": "2022-12-28",
+      "end": "2022-12-30",
+      "daysCount": 3,
+      "timeslot_duration": "00:05",
+      "time_zone_name": "Europe/Zurich"
+    },
+    "rooms": [
+      {
+        "name": "Winterchaos",
+        "guid": "99411f15-7335-4d36-abac-3ff0419ec954",
+        "description": "Talks at LuXerias and LABOR Luzerns Winterchaos 2022",
+        "capacity": null
+      }
+    ],
+    "days": [
+      {% assign days = site.sessions | group_by: "day" | sort: "name" %}
+      {% assign all_sessions = days | map: "items" %}
+      {% assign all_speakers = all_sessions | map: "speaker" | join: ", " | split: ", " | uniq %}
+      {% assign i = 1 %}
+      {% for day in days %}
+        {
+          "index": {{ i }},
+          "date": "{{ day.name }}",
+          "day_start": "{{ day.name }}T00:00:00+01:00",
+          "day_end": "{{ day.name }}T00:00:00+01:00",
+          "rooms": {
+            "Winterchaos": [
+              {% assign sessions = day.items | where: "public", true | sort: "start" %}
+              {% for session in sessions %}
+              {
+                "id": "{{ session.talk_id }}",
+                "guid": "8e3616f7-df59-4f67-847d-783fea4a{{ session.talk_id }}",
+                "logo": "",
+                "date": "{{ session.day }}T{{ session.start }}:00+01:00",
+                "duration": "00:45",
+                "room": "Winterchaos",
+                "url": "{{ session | absolute_url }}",
+                "title": "{{ session.title }}",
+                "subtitle": "",
+                "track": "Winterchaos",
+                "type": "{{ session.type }}",
+                "language": "{{ session.lang | downcase }}",
+                "abstract": "{{ session.short | strip_newlines }}",
+                "description": "{{ session.desc | escape | newline_to_br | strip_newlines }}",
+                "recording_license": "",
+                "do_not_record": {{ session.do_not_record }},
+                {% assign speakers = session.speaker | split: ", " %}
+                "persons": [
+                  {% for speaker in speakers %}
+                    {
+                      {% for s in all_speakers %}
+                        {% if s == speaker %}
+                          {% assign speaker_id = forloop.index0 %}
+                          {% break %} 
+                        {% endif %}
+                      {% endfor %}
+                      "id": {{ speaker_id }},
+                      "code": "{{ speaker | upcase | slice: 0, 3}}{{ speaker_id }}", 
+                      "public_name": "{{ speaker }}",
+                      "bibliography": "",
+                      "answers": []
+                    }{% unless forloop.last %},{% endunless %}
+                    {% endfor %}
+                ],
+                "links": [],
+                "attachments": [],
+                "answers": []
+              }{% unless forloop.last %},{% endunless %}
+              {% endfor %}
+            ]
+          }
+        }{% unless forloop.last %},{% endunless %}
+        {% assign i = i | plus:1 %}
+      {% endfor %}
+    ]
+  }
+}

--- a/_pages/schedule.json.liquid
+++ b/_pages/schedule.json.liquid
@@ -13,7 +13,68 @@ layout: null
       "end": "2022-12-30",
       "daysCount": 3,
       "timeslot_duration": "00:05",
-      "time_zone_name": "Europe/Zurich"
+      "time_zone_name": "Europe/Zurich",
+      "days": [
+        {% assign days = site.sessions | group_by: "day" | sort: "name" %}
+        {% assign all_sessions = days | map: "items" %}
+        {% assign all_speakers = all_sessions | map: "speaker" | join: ", " | split: ", " | uniq %}
+        {% assign i = 1 %}
+        {% for day in days %}
+          {
+            "index": {{ i }},
+            "date": "{{ day.name }}",
+            "day_start": "{{ day.name }}T13:00:00+01:00",
+            "day_end": "{{ day.name }}T23:59:59+01:00",
+            "rooms": {
+              "Winterchaos": [
+                {% assign sessions = day.items | where: "public", true | sort: "start" %}
+                {% for session in sessions %}
+                {
+                  "id": "{{ session.talk_id }}",
+                  "guid": "8e3616f7-df59-4f67-847d-783fea4a{{ session.talk_id }}",
+                  "logo": "",
+                  "date": "{{ session.day }}T{{ session.start }}:00+01:00",
+                  "duration": "00:45",
+                  "room": "Winterchaos",
+                  "url": "{{ session | absolute_url }}",
+                  "title": "{{ session.title }}",
+                  "subtitle": "",
+                  "track": "Winterchaos",
+                  "type": "{{ session.type }}",
+                  "language": "{{ session.lang | downcase }}",
+                  "abstract": "{{ session.short | strip_newlines }}",
+                  "description": "{{ session.desc | escape | newline_to_br | strip_newlines }}",
+                  "recording_license": "",
+                  "do_not_record": {{ session.do_not_record }},
+                  {% assign speakers = session.speaker | split: ", " %}
+                  "persons": [
+                    {% for speaker in speakers %}
+                      {
+                        {% for s in all_speakers %}
+                          {% if s == speaker %}
+                            {% assign speaker_id = forloop.index0 %}
+                            {% break %}
+                          {% endif %}
+                        {% endfor %}
+                        "id": {{ speaker_id }},
+                        "code": "{{ speaker | upcase | slice: 0, 3}}{{ speaker_id }}",
+                        "public_name": "{{ speaker }}",
+                        "bibliography": "",
+                        "answers": []
+                      }{% unless forloop.last %},{% endunless %}
+                      {% endfor %}
+                  ],
+                  "links": [],
+                  "attachments": [],
+                  "answers": []
+                }{% unless forloop.last %},{% endunless %}
+                {% endfor %}
+              ]
+            }
+          }{% unless forloop.last %},{% endunless %}
+          {% assign i = i | plus:1 %}
+        {% endfor %}
+      ]
     },
     "rooms": [
       {
@@ -22,67 +83,6 @@ layout: null
         "description": "Talks at LuXerias and LABOR Luzerns Winterchaos 2022",
         "capacity": null
       }
-    ],
-    "days": [
-      {% assign days = site.sessions | group_by: "day" | sort: "name" %}
-      {% assign all_sessions = days | map: "items" %}
-      {% assign all_speakers = all_sessions | map: "speaker" | join: ", " | split: ", " | uniq %}
-      {% assign i = 1 %}
-      {% for day in days %}
-        {
-          "index": {{ i }},
-          "date": "{{ day.name }}",
-          "day_start": "{{ day.name }}T00:00:00+01:00",
-          "day_end": "{{ day.name }}T00:00:00+01:00",
-          "rooms": {
-            "Winterchaos": [
-              {% assign sessions = day.items | where: "public", true | sort: "start" %}
-              {% for session in sessions %}
-              {
-                "id": "{{ session.talk_id }}",
-                "guid": "8e3616f7-df59-4f67-847d-783fea4a{{ session.talk_id }}",
-                "logo": "",
-                "date": "{{ session.day }}T{{ session.start }}:00+01:00",
-                "duration": "00:45",
-                "room": "Winterchaos",
-                "url": "{{ session | absolute_url }}",
-                "title": "{{ session.title }}",
-                "subtitle": "",
-                "track": "Winterchaos",
-                "type": "{{ session.type }}",
-                "language": "{{ session.lang | downcase }}",
-                "abstract": "{{ session.short | strip_newlines }}",
-                "description": "{{ session.desc | escape | newline_to_br | strip_newlines }}",
-                "recording_license": "",
-                "do_not_record": {{ session.do_not_record }},
-                {% assign speakers = session.speaker | split: ", " %}
-                "persons": [
-                  {% for speaker in speakers %}
-                    {
-                      {% for s in all_speakers %}
-                        {% if s == speaker %}
-                          {% assign speaker_id = forloop.index0 %}
-                          {% break %} 
-                        {% endif %}
-                      {% endfor %}
-                      "id": {{ speaker_id }},
-                      "code": "{{ speaker | upcase | slice: 0, 3}}{{ speaker_id }}", 
-                      "public_name": "{{ speaker }}",
-                      "bibliography": "",
-                      "answers": []
-                    }{% unless forloop.last %},{% endunless %}
-                    {% endfor %}
-                ],
-                "links": [],
-                "attachments": [],
-                "answers": []
-              }{% unless forloop.last %},{% endunless %}
-              {% endfor %}
-            ]
-          }
-        }{% unless forloop.last %},{% endunless %}
-        {% assign i = i | plus:1 %}
-      {% endfor %}
     ]
   }
 }

--- a/_sessions/2814-internal-network-penetration-testing-basics.html
+++ b/_sessions/2814-internal-network-penetration-testing-basics.html
@@ -27,4 +27,6 @@ day: "2022-12-28"
 start: "14:00"
 
 public: true
+talk_id: "2814"
+do_not_record: true
 ---

--- a/_sessions/2815-eine-einfuehrung-in-post-quantum-kryptographie.html
+++ b/_sessions/2815-eine-einfuehrung-in-post-quantum-kryptographie.html
@@ -16,4 +16,6 @@ day: "2022-12-28"
 start: "15:00"
 
 public: true
+talk_id: "2815"
+do_not_record: true
 ---

--- a/_sessions/2817-how-to-manage-an-iot-fleet-with-oss.html
+++ b/_sessions/2817-how-to-manage-an-iot-fleet-with-oss.html
@@ -13,4 +13,6 @@ day: "2022-12-28"
 start: "17:00"
 
 public: true
+talk_id: "2817"
+do_not_record: true
 ---

--- a/_sessions/2818-opensource-luftqualitaets-monitoring-fuer-zuhause.html
+++ b/_sessions/2818-opensource-luftqualitaets-monitoring-fuer-zuhause.html
@@ -12,4 +12,6 @@ day: "2022-12-28"
 start: "18:00"
 
 public: true
+talk_id: "2818"
+do_not_record: true
 ---

--- a/_sessions/2820-how-we-founded-a-citizen-television-station.html
+++ b/_sessions/2820-how-we-founded-a-citizen-television-station.html
@@ -16,4 +16,6 @@ day: "2022-12-28"
 start: "20:00"
 
 public: true
+talk_id: "2820"
+do_not_record: true
 ---

--- a/_sessions/2914-random-intro-to-vsphere.html
+++ b/_sessions/2914-random-intro-to-vsphere.html
@@ -14,4 +14,6 @@ start: "14:00"
 remote: true
 
 public: true
+talk_id: "2914"
+do_not_record: true
 ---

--- a/_sessions/2915-nitratauswaschung-aus-der-landwirtschaft-ins-grundwasser.html
+++ b/_sessions/2915-nitratauswaschung-aus-der-landwirtschaft-ins-grundwasser.html
@@ -11,4 +11,6 @@ day: "2022-12-29"
 start: "15:00"
 
 public: true
+talk_id: "2915"
+do_not_record: true
 ---

--- a/_sessions/2917-ausweiszwang.html
+++ b/_sessions/2917-ausweiszwang.html
@@ -15,4 +15,6 @@ day: "2022-12-29"
 start: "17:00"
 
 public: true
+talk_id: "2917"
+do_not_record: true
 ---

--- a/_sessions/2918-thank-you-for-your-data.html
+++ b/_sessions/2918-thank-you-for-your-data.html
@@ -13,4 +13,6 @@ start: "18:00"
 remote: true
 
 public: true
+talk_id: "2918"
+do_not_record: true
 ---

--- a/_sessions/2920-der-frosch-im-wasserglas.html
+++ b/_sessions/2920-der-frosch-im-wasserglas.html
@@ -13,4 +13,6 @@ day: "2022-12-29"
 start: "20:00"
 
 public: true
+talk_id: "2920"
+do_not_record: true
 ---

--- a/_sessions/2921-real-citizens-living-in-an-ai-painted-model-of-rheinfelden.html
+++ b/_sessions/2921-real-citizens-living-in-an-ai-painted-model-of-rheinfelden.html
@@ -15,4 +15,6 @@ day: "2022-12-29"
 start: "21:00"
 
 public: true
+talk_id: "2921"
+do_not_record: true
 ---

--- a/_sessions/3014-diy-ledcubes.html
+++ b/_sessions/3014-diy-ledcubes.html
@@ -14,4 +14,6 @@ day: "2022-12-30"
 start: "14:00"
 
 public: true
+talk_id: "3014"
+do_not_record: true
 ---

--- a/_sessions/3015-cad-workshop-fuer-anfaenger.html
+++ b/_sessions/3015-cad-workshop-fuer-anfaenger.html
@@ -18,4 +18,6 @@ day: "2022-12-30"
 start: "15:00"
 
 public: true
+talk_id: "3015"
+do_not_record: true
 ---

--- a/_sessions/3017-what-we-have-lost-the-japanese-5th-generation-computer-project.html
+++ b/_sessions/3017-what-we-have-lost-the-japanese-5th-generation-computer-project.html
@@ -12,4 +12,6 @@ day: "2022-12-30"
 start: "17:00"
 
 public: true
+talk_id: "3017"
+do_not_record: true
 ---

--- a/_sessions/3018-git-lets-fck-up-history-and-then-restore-it.html
+++ b/_sessions/3018-git-lets-fck-up-history-and-then-restore-it.html
@@ -16,4 +16,6 @@ start: "18:00"
 remote: true
 
 public: true
+talk_id: "3018"
+do_not_record: true
 ---

--- a/_sessions/3020-modular-synth.html
+++ b/_sessions/3020-modular-synth.html
@@ -18,4 +18,6 @@ day: "2022-12-30"
 start: "20:00"
 
 public: true
+talk_id: "3020"
+do_not_record: true
 ---


### PR DESCRIPTION
The goal of this commit is to export our schedule in a format that it is readable by the official "Fahrplan App". A working example is found here: https://pretalx.c3voc.de/fire-shonks-2022/schedule/export/schedule.json

The following topics need to be discussed/fixes:
- Is there a better way to manage timestamps (e.g. days.day_start or days[n].rooms.Winterchaos[n].date)?
- Is there a better way to handle the sessions guid (e.g. days[n].rooms.Winterchaos[n].guid)?
- Shoudl we intorduce different tracks (e.g. days[n].rooms.Winterchaos[n].track)?
- Should we export the speak duration to the session definition?
- Is the person.id and person.code calculated in a good way?